### PR TITLE
Enable Enterprise Manager Express web interface

### DIFF
--- a/step2/Dockerfile
+++ b/step2/Dockerfile
@@ -14,4 +14,5 @@ RUN mkdir -p $ORACLE_BASE/fast_recovery_area && chown -R oracle:oinstall $ORACLE
 
 ADD initORCL.ora $ORACLE_HOME/dbs/initORCL.ora
 ADD createdb.sql $ORACLE_HOME/config/scripts/createdb.sql
+ADD conf_finish.sql $ORACLE_HOME/config/scripts/conf_finish.sql
 ADD create /tmp/create

--- a/step2/conf_finish.sql
+++ b/step2/conf_finish.sql
@@ -1,0 +1,8 @@
+-- Setting Enterprise Manager Express HTTP ports.
+exec dbms_xdb_config.sethttpsport(5500);
+exec dbms_xdb_config.sethttpport(8080);
+
+-- Shutdown.
+shutdown immediate;
+
+exit;

--- a/step2/create
+++ b/step2/create
@@ -48,5 +48,9 @@ su -s /bin/bash oracle -c "sqlplus system/manager @?/sqlplus/admin/pupbld-e.sql 
 rm pupbld-e.sql
 echo ""
 
+echo "Finalizing install and shutting down the database..."
+su -s /bin/bash oracle -c "sqlplus / as sysdba @?/config/scripts/conf_finish.sql"
+echo ""
+
 date
 echo "Create is done; commit the container now"

--- a/step3/Dockerfile
+++ b/step3/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER Wouter Scherphof <wouter.scherphof@gmail.com>
 
 RUN rm /tmp/create
 
-EXPOSE 1521
+# Exposes the default TNS port, as well as the Enterprise Manager Express HTTP
+# (8080) and HTTPS (5500) ports. 
+EXPOSE 1521 5500 8080
 
 ADD startdb.sql $ORACLE_HOME/config/scripts/startdb.sql
 ADD start /tmp/start


### PR DESCRIPTION
Makes available the Enterprise Manager Express web interface by configuring the corresponding HTTP ports.

This is done here using PL/SQL once the DB is created and running, at the end of step 2. I am not aware of a method of doing the same thing from the response file.